### PR TITLE
Add Babashka support

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Run Babashka tests
         run: bb test-bb
       - name: Run Clojure tests
-        run: clojure -X:test
+        run: bb test-clj

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -20,5 +20,8 @@ jobs:
       - uses: DeLaGuardo/setup-clojure@10.1
         with:
           cli: 1.11.1.1155
-      - name: Run tests
+          bb: 1.0.168
+      - name: Run Babashka tests
+        run: bb test-bb
+      - name: Run Clojure tests
         run: clojure -X:test

--- a/bb.edn
+++ b/bb.edn
@@ -1,24 +1,34 @@
-{:tasks
- {test {:doc "run unit tests"
-        :task (clojure "-X:test")}
+{:deps  {io.github.matthewdowney/rich-comment-tests {:local/root "."}}
+ :paths ["bb"]
+ :tasks
+ {test-bb  {:doc  "run tests for Babashka support"
+            :task test-rct-with-bb/main}
+  test-clj {:doc  "run clj unit tests"
+            :task (clojure "-X:test1")}
+  test     {:doc  "run all tests"
+            :task (do
+                    (println "Running Babashka tests...")
+                    (run 'test-bb)
 
-  coords {:doc "update the dependency coordinates in README.md"
-          :requires ([clojure.string :refer [split split-lines replace]]
-                     [babashka.process :refer [sh shell]])
-          :task (let [tag (->> (sh "git" "tag") :out split-lines peek)
-                      sha (-> (sh "bash -c 'git log | head -1'")
-                            :out
-                            (split (re-pattern " "))
-                            second
-                            (subs 0 7))
-                      coords (str "{" (pr-str :git/tag tag :git/sha sha) "}")
-                      dep "io.github.matthewdowney/rich-comment-tests"]
+                    (println "Running CLJ tests...")
+                    (run 'test-clj))}
 
-                  (spit "README.md"
-                    (-> (slurp "README.md")
-                        (replace
-                          (re-pattern (format "(?s)%s \\{:git/tag \"[^\\}]+\\}" dep))
-                          (format "%s %s" dep coords))))
+  coords   {:doc      "update the dependency coordinates in README.md"
+            :requires ([clojure.string :refer [split split-lines replace]]
+                       [babashka.process :refer [sh shell]])
+            :task     (let [tag (->> (sh "git" "tag") :out split-lines peek)
+                            sha (-> (sh "bash -c 'git log | head -1'")
+                                  :out
+                                  (split (re-pattern " "))
+                                  second
+                                  (subs 0 7))
+                            coords (str "{" (pr-str :git/tag tag :git/sha sha) "}")
+                            dep "io.github.matthewdowney/rich-comment-tests"]
 
-                  (shell "git diff README.md"))}
-  }}
+                        (spit "README.md"
+                          (-> (slurp "README.md")
+                            (replace
+                              (re-pattern (format "(?s)%s \\{:git/tag \"[^\\}]+\\}" dep))
+                              (format "%s %s" dep coords))))
+
+                        (shell "git diff README.md"))}}}

--- a/bb.edn
+++ b/bb.edn
@@ -4,13 +4,13 @@
  {test-bb  {:doc  "run tests for Babashka support"
             :task test-rct-with-bb/main}
   test-clj {:doc  "run clj unit tests"
-            :task (clojure "-X:test1")}
+            :task (clojure "-X:test")}
   test     {:doc  "run all tests"
             :task (do
                     (println "Running Babashka tests...")
                     (run 'test-bb)
 
-                    (println "Running CLJ tests...")
+                    (println "\nRunning CLJ tests...")
                     (run 'test-clj))}
 
   coords   {:doc      "update the dependency coordinates in README.md"

--- a/bb/test_helpers.bb
+++ b/bb/test_helpers.bb
@@ -1,0 +1,51 @@
+(ns test-helpers
+  (:require
+    [clojure.string :as str]
+    [clojure.test :refer [is] :as test]
+    [com.mjdowney.rich-comment-tests :as rct]
+    [com.mjdowney.rich-comment-tests.emit-tests :as tests]))
+
+(defn rct
+  "Stick a single RCT assertion string into a comment block and run it,
+  returning any test output."
+  [s]
+  (let [rct-data
+        (->> (rewrite-clj.zip/of-string
+               (str "^:rct/test\n (comment\n" s "\n)")
+               {:track-position? true})
+             rct/rct-zlocs
+             (mapcat rct/rct-data-seq))]
+    (is (= (count rct-data) 1) "parses one rct")
+
+    (let [form (tests/emit-test-form rct-data)]
+      (is (some? form) "emits a sexpr")
+      (with-out-str
+        (binding [test/*test-out* *out*
+                  test/*report-counters* (atom test/*initial-report-counters*)]
+          (eval form))))))
+
+(defn quote-str [s]
+  (->> (str/split-lines s)
+       (map #(str \tab ">" \tab %))
+       (str/join \newline)))
+
+(defmacro passes? [s]
+  (let [rsym (gensym "result")
+        qsym (gensym "quoted-result")]
+    `(let [~rsym (rct ~s)
+           ~qsym (quote-str ~rsym)]
+       (clojure.test/is
+         (= ~rsym "")
+         (str "no test failures running the form, but have\n" ~qsym)))))
+
+(defmacro fails? [s & contains-failure-msgs]
+  (let [rsym (gensym "result")
+        qsym (gensym "quoted-result")]
+    `(let [~rsym (rct ~s)
+           ~qsym (quote-str ~rsym)]
+       ~@(map
+           (fn [msg]
+             `(clojure.test/is
+                (.contains ~rsym ~msg)
+                (str "test fails with: " ~msg "\nhave:\n" ~qsym)))
+           contains-failure-msgs))))

--- a/bb/test_helpers.bb
+++ b/bb/test_helpers.bb
@@ -3,14 +3,15 @@
     [clojure.string :as str]
     [clojure.test :refer [is] :as test]
     [com.mjdowney.rich-comment-tests :as rct]
-    [com.mjdowney.rich-comment-tests.emit-tests :as tests]))
+    [com.mjdowney.rich-comment-tests.emit-tests :as tests]
+    [rewrite-clj.zip :as z]))
 
 (defn rct
   "Stick a single RCT assertion string into a comment block and run it,
   returning any test output."
   [s]
   (let [rct-data
-        (->> (rewrite-clj.zip/of-string
+        (->> (z/of-string
                (str "^:rct/test\n (comment\n" s "\n)")
                {:track-position? true})
              rct/rct-zlocs

--- a/bb/test_rct_with_bb.bb
+++ b/bb/test_rct_with_bb.bb
@@ -50,8 +50,6 @@
   (range 3) ;=> (0 1 2)
   (+ 5 5) ;; => 10
 
-  (+ 1 1) ;=> 3
-
   ;; Pattern matching assertions with =>>
   (+ 5 5) ;=>> int?
   (def response {:status 200 :body "ok"})

--- a/bb/test_rct_with_bb.bb
+++ b/bb/test_rct_with_bb.bb
@@ -1,0 +1,68 @@
+(ns test-rct-with-bb
+  "Test that RCT runs on Babashka, too."
+  (:require [clojure.string :as str]
+            [clojure.test :as test]
+            [clojure.test :refer [deftest is testing]]
+            [com.mjdowney.rich-comment-tests :as rct]
+            [test-helpers :as t]))
+
+(deftest rct-tests
+  (testing "simple assertions"
+    (t/passes? "(range 3) ;=> (0 1 2)")
+    (t/fails? "(range 3) ;=> (0 2 2)" "actual: (not (= (0 1 2) (0 2 2)))")
+
+    (t/passes?
+      "(+ 5 5)
+      ; => 10")
+
+    (t/fails?
+      "; 5 times 5
+      (* 5 5) ;=> 35"
+
+      "; 5 times 5" ; includes the context
+      "actual: (not (= 25 35))"))
+
+  (testing "reflective tests"
+    (testing "when evaluating a :rct/test comment form in a .bb file"
+      (binding [test/*report-counters* (atom test/*initial-report-counters*)]
+        (is (= (rct/run-ns-tests! 'test-rct-with-bb)
+               {:test 1 :pass 4 :fail 0 :error 0})
+            "the tests pass"))))
+
+  (testing "compatible subset of matcho assertions"
+    (t/passes? "(+ 5 5) ;;=>> int?")
+    (t/fails? "(+ 5 5) ;;=>> string?" "Matcho pattern mismatch:"))
+
+  ;; TODO: Figure out how to make these pass :)
+  #_(testing "(still) incompatible subset of matcho assertions"
+      (t/passes? "(range 3) ;;=>> '(0 1 2)")
+      (t/passes? "(assoc {} :foo :bar :bar :baz) ;;=>> {:foo :bar ...}")
+      (t/passes? "(+ 5 5) ;=>> 10"))
+
+  #_(testing "includes file names and line numbers in assertions"
+      (is (str/starts-with? (t/rct "(+ 1 1) ;=> 3")
+                            "\nFAIL in () (rct_babashka_test.bb:2)\n"))))
+
+^:rct/test
+(comment
+  ;; Literal assertions with =>
+  (range 3) ;=> (0 1 2)
+  (+ 5 5) ;; => 10
+
+  ;; Pattern matching assertions with =>>
+  (+ 5 5) ;=>> int?
+  (def response {:status 200 :body "ok"})
+  response
+  ;=>> {:status #(< % 300)
+  ;     :body   not-empty}
+
+  ;; Or with spec
+  (require '[clojure.spec.alpha :as s])
+  (into {} (System/getProperties))) ;=>> (s/map-of string? string?)
+
+(defn main []
+  (let [{:keys [fail error] :as results}
+        (clojure.test/test-ns 'test-rct-with-bb)]
+    (println results)
+    (when (pos? (+ fail error))
+      (System/exit 1))))

--- a/bb/test_rct_with_bb.bb
+++ b/bb/test_rct_with_bb.bb
@@ -30,15 +30,13 @@
         (is (= ns-tests-result {:test 1 :pass 4 :fail 0 :error 0})
             "tests passing"))))
 
-  (testing "compatible subset of matcho assertions"
+  (testing "matcho assertions"
     (t/passes? "(+ 5 5) ;;=>> int?")
-    (t/fails? "(+ 5 5) ;;=>> string?" "Matcho pattern mismatch:"))
+    (t/fails? "(+ 5 5) ;;=>> string?" "Matcho pattern mismatch:")
 
-  ;; TODO: Figure out how to make these pass :)
-  #_(testing "(still) incompatible subset of matcho assertions"
-      (t/passes? "(range 3) ;;=>> '(0 1 2)")
-      (t/passes? "(assoc {} :foo :bar :bar :baz) ;;=>> {:foo :bar ...}")
-      (t/passes? "(+ 5 5) ;=>> 10"))
+    (t/passes? "(range 3) ;;=>> '(0 1 2)")
+    (t/passes? "(assoc {} :foo :bar :bar :baz) ;;=>> {:foo :bar ...}")
+    (t/passes? "(+ 5 5) ;=>> 10"))
 
   #_(testing "includes file names and line numbers in assertions"
       (is (str/starts-with? (t/rct "(+ 1 1) ;=> 3")
@@ -51,7 +49,9 @@
   (+ 5 5) ;; => 10
 
   ;; Pattern matching assertions with =>>
+  (range 3) ;=>> '(0 1 ...)
   (+ 5 5) ;=>> int?
+
   (def response {:status 200 :body "ok"})
   response
   ;=>> {:status #(< % 300)
@@ -59,7 +59,8 @@
 
   ;; Or with spec
   (require '[clojure.spec.alpha :as s])
-  (into {} (System/getProperties))) ;=>> (s/map-of string? string?)
+  (into {} (System/getProperties)) ;=>> (s/map-of string? string?)
+  )
 
 (defn main []
   (let [{:keys [fail error] :as results}
@@ -67,3 +68,9 @@
     (println results)
     (when (pos? (+ fail error))
       (System/exit 1))))
+
+(comment
+  (rct/run-file-tests!
+    "src/com/mjdowney/rich_comment_tests.cljc"
+    (find-ns 'com.mjdowney.rich-comment-tests))
+  )

--- a/bb/test_rct_with_bb.bb
+++ b/bb/test_rct_with_bb.bb
@@ -24,10 +24,11 @@
 
   (testing "reflective tests"
     (testing "when evaluating a :rct/test comment form in a .bb file"
-      (binding [test/*report-counters* (atom test/*initial-report-counters*)]
-        (is (= (rct/run-ns-tests! 'test-rct-with-bb)
-               {:test 1 :pass 4 :fail 0 :error 0})
-            "the tests pass"))))
+      (let [ns-tests-result
+            (binding [test/*report-counters* (atom test/*initial-report-counters*)]
+              (rct/run-ns-tests! 'test-rct-with-bb))]
+        (is (= ns-tests-result {:test 1 :pass 4 :fail 0 :error 0})
+            "tests passing"))))
 
   (testing "compatible subset of matcho assertions"
     (t/passes? "(+ 5 5) ;;=>> int?")
@@ -48,6 +49,8 @@
   ;; Literal assertions with =>
   (range 3) ;=> (0 1 2)
   (+ 5 5) ;; => 10
+
+  (+ 1 1) ;=> 3
 
   ;; Pattern matching assertions with =>>
   (+ 5 5) ;=>> int?

--- a/bb/test_rct_with_bb.bb
+++ b/bb/test_rct_with_bb.bb
@@ -27,7 +27,7 @@
       (let [ns-tests-result
             (binding [test/*report-counters* (atom test/*initial-report-counters*)]
               (rct/run-ns-tests! 'test-rct-with-bb))]
-        (is (= ns-tests-result {:test 1 :pass 4 :fail 0 :error 0})
+        (is (= ns-tests-result {:test 1 :pass 6 :fail 0 :error 0})
             "tests passing"))))
 
   (testing "matcho assertions"

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  :deps    {org.clojure/clojure         {:mvn/version "1.11.1"}
            org.clojure/tools.namespace {:mvn/version "1.3.0"}
            rewrite-clj/rewrite-clj     {:mvn/version "1.1.45"}
-           healthsamurai/matcho        {:mvn/version "0.3.9"}}
+           healthsamurai/matcho        {:mvn/version "0.3.10"}}
  :aliases {:test  {:extra-paths ["test"]
                    :extra-deps  {io.github.cognitect-labs/test-runner {:git/tag "v0.5.0" :git/sha "b3fd0d2"}}
                    :main-opts   ["--report" "stderr"

--- a/src/com/mjdowney/rich_comment_tests.cljc
+++ b/src/com/mjdowney/rich_comment_tests.cljc
@@ -311,7 +311,8 @@
             {:type :error
              :message "Uncaught exception, not in assertion."
              :expected nil
-             :actual e}))))))
+             :actual e}))))
+    @test/*report-counters*))
 
 (defn run-file-tests!
   "Take a file path and the namespace it corresponds to, and run tests."
@@ -360,7 +361,8 @@
                ; Isolate this test that we expect to fail, in case this snippet
                ; is being run from clojure.test, so that its failure isn't
                ; counted with other test failures.
-               test/*report-counters* (ref test/*initial-report-counters*)]
+               test/*report-counters* (#?(:bb atom :clj ref)
+                                        test/*initial-report-counters*)]
        (do ~@body)
        (string/trim (.toString sw#)))))
 

--- a/src/com/mjdowney/rich_comment_tests.cljc
+++ b/src/com/mjdowney/rich_comment_tests.cljc
@@ -280,7 +280,9 @@
   [& body]
   `(if (clojure-test-reporting-active?)
      (do ~@body)
-     (binding [test/*report-counters* (ref test/*initial-report-counters*)]
+     ; bb version of clojure.test uses atoms to store this state
+     (binding [test/*report-counters* (#?(:bb atom :clj ref)
+                                        test/*initial-report-counters*)]
        (test/do-report {:type :begin-test-ns :ns *ns*})
        (let [ret# (do ~@body)]
          (test/do-report {:type :end-test-ns   :ns *ns*})
@@ -380,7 +382,7 @@
   ; strings, etc.
   (string/includes?
     *1
-    "(rich_comment_tests.clj:5)
+    "(rich_comment_tests.cljc:5)
 ;; When asserting impossibilities...
 ;; The test fails
 
@@ -403,13 +405,13 @@ expected: (= (+ 1 1) 3)
   (capture-clojure-test-out
     (run-tests* (z/of-string matcho-assert-that-fails {:track-position? true})))
 
-  (string/includes? *1 "(rich_comment_tests.clj:4)") ;=> true
+  (string/includes? *1 "(rich_comment_tests.cljc:4)") ;=> true
   (string/includes? *2 "Matcho pattern mismatch:") ;=> true
 
   ;; Same assertion, but using matcho itself
   (capture-clojure-test-out
     (run-tests* (z/of-string matcho-assert-that-fails {:track-position? true})))
-  ;=>> #".*FAIL in \(.*\) \(rich_comment_tests.clj:4\).*"
+  ;=>> #".*FAIL in \(.*\) \(rich_comment_tests.cljc:4\).*"
   )
 
 ;; Demo some kinds of test assertions

--- a/src/com/mjdowney/rich_comment_tests/emit_tests.clj
+++ b/src/com/mjdowney/rich_comment_tests/emit_tests.clj
@@ -114,11 +114,14 @@
       (dissoc :expectation-type)
       read-expectation-form))
 
+; Workaround for Babashka where the *file* is not available from test code
+(defmacro -*file* [] `(if *file* (.getName (io/file *file*)) "unknown_file"))
+
 (defmethod emit-assertion :default
-  [{:keys [expectation-type location] :as data} expectation-form]
+  [{:keys [expectation-type location] :as data} _expectation-form]
   (let [err (format "Unknown expectation string type ;%s at %s:%s"
                     expectation-type
-                    (.getName (io/file *file*))
+                    (-*file*)
                     (first location))]
     (throw (ex-info err data))))
 
@@ -127,20 +130,21 @@
   [{:keys [context-strings test-sexpr location]} expectation-form]
   (let [message (last context-strings)
         line-number (first location)
-        fname (.getName (io/file *file*))
+        fname (-*file*)
         test-form (list '= test-sexpr expectation-form)]
     `(let [form-result# ~(try-bind-repl-vars test-sexpr line-number *file*)
            test-result# (= form-result# '~expectation-form)]
 
        (if test-result#
-         (test/do-report
+         ; n.b. this needs to be fully qualified for babashka
+         (clojure.test/do-report
            {:type :pass,
             :message ~message
             :expected '~test-form
             :actual '~test-form
             :line ~line-number
             :file ~fname})
-         (test/do-report
+         (clojure.test/do-report
            {:type     :fail,
             :message  ~message
             :expected '~test-form
@@ -158,9 +162,9 @@
   [{:keys [context-strings test-sexpr location]} expectation-form]
   (let [message (last context-strings)
         line (first location)
-        fname (.getName (io/file *file*))]
+        fname (-*file*)]
     (?enclose
-      (when message `(test/testing ~(str \newline message)))
+      (when message `(clojure.test/testing ~(str \newline message)))
       `(let [form-result# ~(try-bind-repl-vars test-sexpr line *file*)
              ; Rebind do-report to include the file name and line number, since
              ; matcho doesn't expose a way for us to set these

--- a/src/com/mjdowney/rich_comment_tests/emit_tests.clj
+++ b/src/com/mjdowney/rich_comment_tests/emit_tests.clj
@@ -21,11 +21,12 @@
   `(let [form-result#
          (try ~form
               (catch Exception e#
-                (set! *e e#)
+                (when (thread-bound? #'*e) (set! *e e#))
                 (throw-evaluation-error '~form ~line-number ~file e#)))]
-     (set! *3 *2)
-     (set! *2 *1)
-     (set! *1 form-result#)))
+     (when (thread-bound? #'*3) (set! *3 *2))
+     (when (thread-bound? #'*2) (set! *2 *1))
+     (when (thread-bound? #'*1) (set! *1 form-result#))
+     form-result#))
 
 ;; Add color to the exception if the supplied expectation string is malformed
 ;; E.g. in the case of ;=> "Oops, the quotes aren't balanced...


### PR DESCRIPTION
I'm opening this PR to track progress, but it's not quite ready to merge yet.

So far we have 
- Support for running `;=>` assertions from Babashka, albeit without file names / numbers.
- Support for a subset of `;=>>` assertions (mirroring whatever matcho supports out of the box).