### PR TITLE
Update Clojars on each push of new tag to master

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -7,8 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
-
+  test:
     runs-on: ubuntu-latest
 
     steps:
@@ -27,3 +26,33 @@ jobs:
         run: bb test-bb-run-tests-in-file-tree
       - name: Run Clojure tests
         run: bb test-clj
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [test]
+    if: ${{ github.event_name == 'push' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Prepare java
+        uses: actions/setup-java@v1
+        with: { java-version: 1.11 }
+
+      - name: Install clojure tools
+        uses: DeLaGuardo/setup-clojure@10.0
+        with:
+          cli: latest
+          bb: latest
+
+      - name: Build jar
+        run: bb uber
+
+      - name: Deploy to clojars
+        env:
+          CLOJARS_USERNAME: ${{ secrets.CLOJARS_USERNAME }}
+          CLOJARS_PASSWORD: ${{ secrets.CLOJARS_PASSWORD }}
+        run: bb deploy

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -30,7 +30,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: [test]
-    if: ${{ github.event_name == 'push' }}
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
 
     steps:
       - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.cpcache/
+.nrepl-port
+target/

--- a/bb.edn
+++ b/bb.edn
@@ -32,17 +32,27 @@
               [babashka.process :refer [sh shell]])
    :task     (let [tag (->> (sh "git" "tag") :out split-lines peek)
                    sha (-> (sh "bash -c 'git log | head -1'")
-                         :out
-                         (split (re-pattern " "))
-                         second
-                         (subs 0 7))
+                           :out
+                           (split (re-pattern " "))
+                           second
+                           (subs 0 7))
                    coords (str "{" (pr-str :git/tag tag :git/sha sha) "}")
                    dep "io.github.matthewdowney/rich-comment-tests"]
 
                (spit "README.md"
-                 (-> (slurp "README.md")
-                   (replace
-                     (re-pattern (format "(?s)%s \\{:git/tag \"[^\\}]+\\}" dep))
-                     (format "%s %s" dep coords))))
+                     (-> (slurp "README.md")
+                         (replace
+                          (re-pattern (format "(?s)%s \\{:git/tag \"[^\\}]+\\}" dep))
+                          (format "%s %s" dep coords))))
 
-               (shell "git diff README.md"))}}}
+               (shell "git diff README.md"))}
+
+  uber {:doc "Build uberjar"
+        :task (do
+                (println "Building uberjar...")
+                (clojure "-T:build jar"))}
+
+  deploy {:doc "Deploy to Clojars"
+          :task (do
+                  (println "Deploying to clojars")
+                  (clojure "-T:build deploy"))}}}

--- a/build.clj
+++ b/build.clj
@@ -1,0 +1,40 @@
+(ns build
+  (:require [clojure.tools.build.api :as b]
+            [clojure.string :as str]
+            [org.corfield.build :as bb]
+            [clojure.java.shell :refer [sh]]))
+
+(defn git-tag []
+  (let [tag (->> (sh "git" "tag") :out str/split-lines peek)]
+    (if (seq tag) tag "0.1-SNAPSHOT")))
+
+(def lib 'io.github.matthewdowney/rich-comment-tests)
+(def main 'com.mjdowney.rich-comment-tests)
+(def version (git-tag))
+(def class-dir "target/classes")
+(def basis (b/create-basis {:project "deps.edn"}))
+(def jar-file (format "target/%s-%s.jar" (name lib) version))
+
+(defn clean [_]
+  (b/delete {:path "target"}))
+
+(defn jar [_]
+  (b/write-pom {:class-dir class-dir
+                :lib lib
+                :version version
+                :basis basis
+                :scm {:url "https://github.com/matthewdowney/rich-comment-tests"
+                      :connection "scm:git:git://github.com/matthewdowney/rich-comment-tests.git"
+                      :developerConnection "scm:git:ssh://git@github.com/matthewdowney/rich-comment-tests.git"}
+                :src-dirs ["src"]})
+  (b/copy-dir {:src-dirs ["src" "resources"]
+               :target-dir class-dir})
+  (b/jar {:class-dir class-dir
+          :jar-file jar-file}))
+
+(defn deploy "Deploy the JAR to Clojars." [{:as opts}]
+  (-> opts
+      (assoc :lib lib
+             :version version
+             :main main)
+      (bb/deploy)))

--- a/deps.edn
+++ b/deps.edn
@@ -9,4 +9,8 @@
                                  "-m" "cognitect.test-runner"]
                    :exec-fn     cognitect.test-runner.api/test}
            :test1 {:exec-fn   com.mjdowney.rich-comment-tests.test-runner/run-tests-in-file-tree!
-                   :exec-args {:dirs #{"src"}}}}}
+                   :exec-args {:dirs #{"src"}}}
+
+           :build {:ns-default build
+                  :deps {io.github.seancorfield/build-clj {:git/tag "v0.8.3" :git/sha "7ac1f8d"}
+                               io.github.clojure/tools.build {:git/tag "v0.9.4" :git/sha "76b78fe"}}}}}


### PR DESCRIPTION
Added build.clj and tasks to bb.edn, to run from clojure.yml and deploy to Clojars on each new version.

Will need the following secrets:
- `CLOJARS_USERNAME`
- `CLOJARS_PASSWORD`

https://github.com/matthewdowney/rich-comment-tests/issues/21